### PR TITLE
Fix readm emd

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,27 +24,23 @@ ODYM was developed to handle the typical types of model equations and approaches
 These approaches include:
 
 __a)	Regression models:__ Socioeconomic parameters, such as in-use stocks or final consumption are required to determine the basic material balance or material flows. They are often determined from regression models fed by exogenous parameters such as GDP. A typical example for a regression model is the Gompertz function, where $a(p,r)$ and $b(p,r)$ are product-and region-dependent scaling parameters. Regression models can also be used to determine future scenarios.
-	   
 ```math 
 i(p,r,t) = i_{Sat}\cdot exp^{-b(p,r)\cdot exp^{-a(p,r)\cdot t}}
 ```
 
-__b)	Dynamic stock model:__ The material stock S and outflow o can be estimated from inflow data i, using a product lifetime distribution $\lambda(t,c)$, which describes the probability of a product of age-cohort c being discarded at time t 
-
+__b)	Dynamic stock model:__ The material stock S and outflow o can be estimated from inflow data i, using a product lifetime distribution $\lambda(t,c)$, which describes the probability of a product of age-cohort c being discarded at time t.
 ```math 
 \begin{eqnarray} o(t)=\sum_{t'\leq t}i(t')\cdot \lambda(t,c = t') \\ S(t)=\sum_{t'\leq t}(i(t')-o(t')) \end{eqnarray}
 ```
 
-__c)	Parameter equation with transfer coefficients:__ The distribution of a material flow to different processes is determined by the transfer coefficient. Consider a flow of different end-of-life products p, $F_p$, with chemical element composition $\mu$. The products are sent to waste treatment by different technologies w, and each technology has its own element-specific yield factor $\Gamma$, which assigns the incoming elements to different scrap groups s and which varies depending on when the technology was installed (age-cohort dependency): $\Gamma = \Gamma(w,e,s,c)$. The flow of chemical elements in the different scrap groups $F_s$ is then
-
+__c)	Parameter equation with transfer coefficients:__ The distribution of a material flow to different processes is determined by the transfer coefficient. Consider a flow of different end-of-life products p, $F_{p} $, with chemical element composition $\mu $. The products are sent to waste treatment by different technologies w, and each technology has its own element-specific yield factor $\Gamma$, which assigns the incoming elements to different scrap groups s and which varies depending on when the technology was installed (age-cohort dependency): $\Gamma = \Gamma(w,e,s,c)$. The flow of chemical elements in the different scrap groups $F_s$ is then:
 ```math 
 F_s(t,s,e) = \sum_{w,p,c}\Gamma(w,e,s,c)\cdot C(w,t,c)\cdot F_p(t,p)\cdot \mu(p,e)
 ```
 
 Where $C(w,t,c)$ is the capacity of the different waste treatment technologies w of age-cohort c in a year t.
 
-__d)	Optimisation:__ For a system with a 1:1 correspondence of industries and markets, which is the basis of input-output models, the application of linear optimisation to select between competing technological alternatives is common. This optimisation approach can also be used to determine waste treatment cascades so that non-functional recycling, costs, or GHG emissions are minimized. A waste cascade optimisation problem has the typical form (Kondo and Nakamura 2005)
-	
+__d)	Optimisation:__ For a system with a 1:1 correspondence of industries and markets, which is the basis of input-output models, the application of linear optimisation to select between competing technological alternatives is common. This optimisation approach can also be used to determine waste treatment cascades so that non-functional recycling, costs, or GHG emissions are minimized. A waste cascade optimisation problem has the typical form (Kondo and Nakamura 2005).
 ```math 
 \begin{eqnarray} min C = c^t\cdot x\\ s.t.\\ w = G\cdot x+y\\ x = S\cdot w \\ x \geq 0
 ```

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Where $C(w,t,c)$ is the capacity of the different waste treatment technologies w
 
 __d)	Optimisation:__ For a system with a 1:1 correspondence of industries and markets, which is the basis of input-output models, the application of linear optimisation to select between competing technological alternatives is common. This optimisation approach can also be used to determine waste treatment cascades so that non-functional recycling, costs, or GHG emissions are minimized. A waste cascade optimisation problem has the typical form (Kondo and Nakamura 2005).
 
-$$ \begin{eqnarray} min \.C = c^t\cdot x\\ 
+$$ \begin{eqnarray} min C = c^t\cdot x\\ 
 s.t.\\ 
 w = G\cdot x+y\\ 
 x = S\cdot w \\ 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Where $C(w,t,c)$ is the capacity of the different waste treatment technologies w
 
 __d)	Optimisation:__ For a system with a 1:1 correspondence of industries and markets, which is the basis of input-output models, the application of linear optimisation to select between competing technological alternatives is common. This optimisation approach can also be used to determine waste treatment cascades so that non-functional recycling, costs, or GHG emissions are minimized. A waste cascade optimisation problem has the typical form (Kondo and Nakamura 2005).
 
-$$ \begin{eqnarray} min C = c^t\cdot x\\ s.t.\\ w = G\cdot x+y\\ x = S\cdot w \\ x \geq 0 $$
+$$ \begin{eqnarray} min C = c^t\cdot x\\ s.t.\\ w = G\cdot x+y\\ x = S\cdot w \\ x \geq 0 \end{eqnarray} $$
 	
 In the above equation, x is the output vector of the different waste treatment plants, c is a cost vector, y is the final demand for waste treatment, G is the waste generation of waste treatment, and S is the allocation of waste to treatment processes.
 	

--- a/README.md
+++ b/README.md
@@ -24,16 +24,17 @@ ODYM was developed to handle the typical types of model equations and approaches
 These approaches include:
 
 __a)	Regression models:__ Socioeconomic parameters, such as in-use stocks or final consumption are required to determine the basic material balance or material flows. They are often determined from regression models fed by exogenous parameters such as GDP. A typical example for a regression model is the Gompertz function, where $a(p,r)$ and $b(p,r)$ are product-and region-dependent scaling parameters. Regression models can also be used to determine future scenarios.
-```math 
-i(p,r,t) = i_{Sat}\cdot exp^{-b(p,r)\cdot exp^{-a(p,r)\cdot t}} 
-```
+
+$$ i(p,r,t) = i_{Sat}\cdot exp^{-b(p,r)\cdot exp^{-a(p,r)\cdot t}} $$
 
 __b)	Dynamic stock model:__ The material stock S and outflow o can be estimated from inflow data i, using a product lifetime distribution $\lambda(t,c)$, which describes the probability of a product of age-cohort c being discarded at time t.
+
 ```math 
 \begin{eqnarray} o(t)=\sum_{t'\leq t}i(t')\cdot \lambda(t,c = t') \\ S(t)=\sum_{t'\leq t}(i(t')-o(t')) \end{eqnarray}
 ```
 
-__c)	Parameter equation with transfer coefficients:__ The distribution of a material flow to different processes is determined by the transfer coefficient. Consider a flow of different end-of-life products p, $F_{p} $, with chemical element composition $\mu $. The products are sent to waste treatment by different technologies w, and each technology has its own element-specific yield factor $\Gamma $, which assigns the incoming elements to different scrap groups s and which varies depending on when the technology was installed (age-cohort dependency): $\Gamma = \Gamma(w,e,s,c) $. The flow of chemical elements in the different scrap groups $F_s$ is then:
+__c)	Parameter equation with transfer coefficients:__ The distribution of a material flow to different processes is determined by the transfer coefficient. Consider a flow of different end-of-life products p, $F_{p} $, with chemical element composition $\mu $. The products are sent to waste treatment by different technologies w, and each technology has its own element-specific yield factor  $\Gamma $, which assigns the incoming elements to different scrap groups s and which varies depending on when the technology was installed (age-cohort dependency):  $\Gamma = \Gamma(w,e,s,c) $. The flow of chemical elements in the different scrap groups $F_s$ is then:
+
 ```math 
 F_s(t,s,e) = \sum_{w,p,c}\Gamma(w,e,s,c)\cdot C(w,t,c)\cdot F_p(t,p)\cdot \mu(p,e) 
 ```
@@ -41,6 +42,7 @@ F_s(t,s,e) = \sum_{w,p,c}\Gamma(w,e,s,c)\cdot C(w,t,c)\cdot F_p(t,p)\cdot \mu(p,
 Where $C(w,t,c)$ is the capacity of the different waste treatment technologies w of age-cohort c in a year t.
 
 __d)	Optimisation:__ For a system with a 1:1 correspondence of industries and markets, which is the basis of input-output models, the application of linear optimisation to select between competing technological alternatives is common. This optimisation approach can also be used to determine waste treatment cascades so that non-functional recycling, costs, or GHG emissions are minimized. A waste cascade optimisation problem has the typical form (Kondo and Nakamura 2005).
+
 ```math 
 \begin{eqnarray} min C = c^t\cdot x\\ s.t.\\ w = G\cdot x+y\\ x = S\cdot w \\ x \geq 0 
 ```

--- a/README.md
+++ b/README.md
@@ -25,21 +25,29 @@ These approaches include:
 
 __a)	Regression models:__ Socioeconomic parameters, such as in-use stocks or final consumption are required to determine the basic material balance or material flows. They are often determined from regression models fed by exogenous parameters such as GDP. A typical example for a regression model is the Gompertz function, where $a(p,r)$ and $b(p,r)$ are product-and region-dependent scaling parameters. Regression models can also be used to determine future scenarios.
 	   
-	$$ i(p,r,t) = i_{Sat}\cdot exp^{-b(p,r)\cdot exp^{-a(p,r)\cdot t}} $$
-     
+```math 
+i(p,r,t) = i_{Sat}\cdot exp^{-b(p,r)\cdot exp^{-a(p,r)\cdot t}}
+```
+
 __b)	Dynamic stock model:__ The material stock S and outflow o can be estimated from inflow data i, using a product lifetime distribution $\lambda(t,c)$, which describes the probability of a product of age-cohort c being discarded at time t 
 
-	$$ \begin{eqnarray} o(t)=\sum_{t'\leq t}i(t')\cdot \lambda(t,c = t') \\ S(t)=\sum_{t'\leq t}(i(t')-o(t')) \end{eqnarray} $$
+```math 
+\begin{eqnarray} o(t)=\sum_{t'\leq t}i(t')\cdot \lambda(t,c = t') \\ S(t)=\sum_{t'\leq t}(i(t')-o(t')) \end{eqnarray}
+```
 
 __c)	Parameter equation with transfer coefficients:__ The distribution of a material flow to different processes is determined by the transfer coefficient. Consider a flow of different end-of-life products p, $F_p$, with chemical element composition $\mu$. The products are sent to waste treatment by different technologies w, and each technology has its own element-specific yield factor $\Gamma$, which assigns the incoming elements to different scrap groups s and which varies depending on when the technology was installed (age-cohort dependency): $\Gamma = \Gamma(w,e,s,c)$. The flow of chemical elements in the different scrap groups $F_s$ is then
 
-	$$ F_s(t,s,e) = \sum_{w,p,c}\Gamma(w,e,s,c)\cdot C(w,t,c)\cdot F_p(t,p)\cdot \mu(p,e)$$
+```math 
+F_s(t,s,e) = \sum_{w,p,c}\Gamma(w,e,s,c)\cdot C(w,t,c)\cdot F_p(t,p)\cdot \mu(p,e)
+```
 
 Where $C(w,t,c)$ is the capacity of the different waste treatment technologies w of age-cohort c in a year t.
 
 __d)	Optimisation:__ For a system with a 1:1 correspondence of industries and markets, which is the basis of input-output models, the application of linear optimisation to select between competing technological alternatives is common. This optimisation approach can also be used to determine waste treatment cascades so that non-functional recycling, costs, or GHG emissions are minimized. A waste cascade optimisation problem has the typical form (Kondo and Nakamura 2005)
 	
-	$$ \begin{eqnarray} min C = c^t\cdot x\\ s.t.\\ w = G\cdot x+y\\ x = S\cdot w \\ x \geq 0 $$
+```math 
+\begin{eqnarray} min C = c^t\cdot x\\ s.t.\\ w = G\cdot x+y\\ x = S\cdot w \\ x \geq 0
+```
 	
 In the above equation, x is the output vector of the different waste treatment plants, c is a cost vector, y is the final demand for waste treatment, G is the waste generation of waste treatment, and S is the allocation of waste to treatment processes.
 	

--- a/README.md
+++ b/README.md
@@ -29,23 +29,17 @@ $$ i(p,r,t) = i_{Sat}\cdot exp^{-b(p,r)\cdot exp^{-a(p,r)\cdot t}} $$
 
 __b)	Dynamic stock model:__ The material stock S and outflow o can be estimated from inflow data i, using a product lifetime distribution $\lambda(t,c)$, which describes the probability of a product of age-cohort c being discarded at time t.
 
-```math 
-\begin{eqnarray} o(t)=\sum_{t'\leq t}i(t')\cdot \lambda(t,c = t') \\ S(t)=\sum_{t'\leq t}(i(t')-o(t')) \end{eqnarray}
-```
+$$ \begin{eqnarray} o(t)=\sum_{t'\leq t}i(t')\cdot \lambda(t,c = t') \\ S(t)=\sum_{t'\leq t}(i(t')-o(t')) \end{eqnarray} $$
 
 __c)	Parameter equation with transfer coefficients:__ The distribution of a material flow to different processes is determined by the transfer coefficient. Consider a flow of different end-of-life products p, $F_{p} $, with chemical element composition $\mu $. The products are sent to waste treatment by different technologies w, and each technology has its own element-specific yield factor  $\Gamma $, which assigns the incoming elements to different scrap groups s and which varies depending on when the technology was installed (age-cohort dependency):  $\Gamma = \Gamma(w,e,s,c) $. The flow of chemical elements in the different scrap groups $F_s$ is then:
 
-```math 
-F_s(t,s,e) = \sum_{w,p,c}\Gamma(w,e,s,c)\cdot C(w,t,c)\cdot F_p(t,p)\cdot \mu(p,e) 
-```
+$$ F_s(t,s,e) = \sum_{w,p,c}\Gamma(w,e,s,c)\cdot C(w,t,c)\cdot F_p(t,p)\cdot \mu(p,e) $$
 
 Where $C(w,t,c)$ is the capacity of the different waste treatment technologies w of age-cohort c in a year t.
 
 __d)	Optimisation:__ For a system with a 1:1 correspondence of industries and markets, which is the basis of input-output models, the application of linear optimisation to select between competing technological alternatives is common. This optimisation approach can also be used to determine waste treatment cascades so that non-functional recycling, costs, or GHG emissions are minimized. A waste cascade optimisation problem has the typical form (Kondo and Nakamura 2005).
 
-```math 
-\begin{eqnarray} min C = c^t\cdot x\\ s.t.\\ w = G\cdot x+y\\ x = S\cdot w \\ x \geq 0 
-```
+$$ \begin{eqnarray} min C = c^t\cdot x\\ s.t.\\ w = G\cdot x+y\\ x = S\cdot w \\ x \geq 0 $$
 	
 In the above equation, x is the output vector of the different waste treatment plants, c is a cost vector, y is the final demand for waste treatment, G is the waste generation of waste treatment, and S is the allocation of waste to treatment processes.
 	

--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ Where $C(w,t,c)$ is the capacity of the different waste treatment technologies w
 
 __d)	Optimisation:__ For a system with a 1:1 correspondence of industries and markets, which is the basis of input-output models, the application of linear optimisation to select between competing technological alternatives is common. This optimisation approach can also be used to determine waste treatment cascades so that non-functional recycling, costs, or GHG emissions are minimized. A waste cascade optimisation problem has the typical form (Kondo and Nakamura 2005).
 
-$$ \begin{eqnarray} min C = c^t\cdot x\\ s.t.\\ w = G\cdot x+y\\ x = S\cdot w \\ x \geq 0 \end{eqnarray} $$
+$$ \begin{eqnarray} min \.C = c^t\cdot x\\ 
+s.t.\\ 
+w = G\cdot x+y\\ 
+x = S\cdot w \\ 
+x \geq 0 \end{eqnarray} $$
 	
 In the above equation, x is the output vector of the different waste treatment plants, c is a cost vector, y is the final demand for waste treatment, G is the waste generation of waste treatment, and S is the allocation of waste to treatment processes.
 	

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ $$ i(p,r,t) = i_{Sat}\cdot exp^{-b(p,r)\cdot exp^{-a(p,r)\cdot t}} $$
 
 __b)	Dynamic stock model:__ The material stock S and outflow o can be estimated from inflow data i, using a product lifetime distribution $\lambda(t,c)$, which describes the probability of a product of age-cohort c being discarded at time t.
 
-$$ \begin{eqnarray} o(t)=\sum_{t'\leq t}i(t')\cdot \lambda(t,c = t') \\ S(t)=\sum_{t'\leq t}(i(t')-o(t')) \end{eqnarray} $$
+$$ \begin{eqnarray} o(t)=\sum_{t'\leq t}i(t')\cdot \lambda(t,c = t') \\ 
+S(t)=\sum_{t'\leq t}(i(t')-o(t')) \end{eqnarray} $$
 
 __c)	Parameter equation with transfer coefficients:__ The distribution of a material flow to different processes is determined by the transfer coefficient. Consider a flow of different end-of-life products p, $F_{p} $, with chemical element composition $\mu $. The products are sent to waste treatment by different technologies w, and each technology has its own element-specific yield factor  $\Gamma $, which assigns the incoming elements to different scrap groups s and which varies depending on when the technology was installed (age-cohort dependency):  $\Gamma = \Gamma(w,e,s,c) $. The flow of chemical elements in the different scrap groups $F_s$ is then:
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ These approaches include:
 
 __a)	Regression models:__ Socioeconomic parameters, such as in-use stocks or final consumption are required to determine the basic material balance or material flows. They are often determined from regression models fed by exogenous parameters such as GDP. A typical example for a regression model is the Gompertz function, where $a(p,r)$ and $b(p,r)$ are product-and region-dependent scaling parameters. Regression models can also be used to determine future scenarios.
 ```math 
-i(p,r,t) = i_{Sat}\cdot exp^{-b(p,r)\cdot exp^{-a(p,r)\cdot t}}
+i(p,r,t) = i_{Sat}\cdot exp^{-b(p,r)\cdot exp^{-a(p,r)\cdot t}} 
 ```
 
 __b)	Dynamic stock model:__ The material stock S and outflow o can be estimated from inflow data i, using a product lifetime distribution $\lambda(t,c)$, which describes the probability of a product of age-cohort c being discarded at time t.
@@ -33,16 +33,16 @@ __b)	Dynamic stock model:__ The material stock S and outflow o can be estimated 
 \begin{eqnarray} o(t)=\sum_{t'\leq t}i(t')\cdot \lambda(t,c = t') \\ S(t)=\sum_{t'\leq t}(i(t')-o(t')) \end{eqnarray}
 ```
 
-__c)	Parameter equation with transfer coefficients:__ The distribution of a material flow to different processes is determined by the transfer coefficient. Consider a flow of different end-of-life products p, $F_{p} $, with chemical element composition $\mu $. The products are sent to waste treatment by different technologies w, and each technology has its own element-specific yield factor $\Gamma$, which assigns the incoming elements to different scrap groups s and which varies depending on when the technology was installed (age-cohort dependency): $\Gamma = \Gamma(w,e,s,c)$. The flow of chemical elements in the different scrap groups $F_s$ is then:
+__c)	Parameter equation with transfer coefficients:__ The distribution of a material flow to different processes is determined by the transfer coefficient. Consider a flow of different end-of-life products p, $F_{p} $, with chemical element composition $\mu $. The products are sent to waste treatment by different technologies w, and each technology has its own element-specific yield factor $\Gamma $, which assigns the incoming elements to different scrap groups s and which varies depending on when the technology was installed (age-cohort dependency): $\Gamma = \Gamma(w,e,s,c) $. The flow of chemical elements in the different scrap groups $F_s$ is then:
 ```math 
-F_s(t,s,e) = \sum_{w,p,c}\Gamma(w,e,s,c)\cdot C(w,t,c)\cdot F_p(t,p)\cdot \mu(p,e)
+F_s(t,s,e) = \sum_{w,p,c}\Gamma(w,e,s,c)\cdot C(w,t,c)\cdot F_p(t,p)\cdot \mu(p,e) 
 ```
 
 Where $C(w,t,c)$ is the capacity of the different waste treatment technologies w of age-cohort c in a year t.
 
 __d)	Optimisation:__ For a system with a 1:1 correspondence of industries and markets, which is the basis of input-output models, the application of linear optimisation to select between competing technological alternatives is common. This optimisation approach can also be used to determine waste treatment cascades so that non-functional recycling, costs, or GHG emissions are minimized. A waste cascade optimisation problem has the typical form (Kondo and Nakamura 2005).
 ```math 
-\begin{eqnarray} min C = c^t\cdot x\\ s.t.\\ w = G\cdot x+y\\ x = S\cdot w \\ x \geq 0
+\begin{eqnarray} min C = c^t\cdot x\\ s.t.\\ w = G\cdot x+y\\ x = S\cdot w \\ x \geq 0 
 ```
 	
 In the above equation, x is the output vector of the different waste treatment plants, c is a cost vector, y is the final demand for waste treatment, G is the waste generation of waste treatment, and S is the allocation of waste to treatment processes.


### PR DESCRIPTION
Dear Marpellan,

On the following pull request you can find fixing on the formatting of the equation of the documentation (on github it is still a bit tricky to get the equations to show well, adding spaces before and after the `$$` did the job).

For ease of use by the end user, you could also add two sections to your readme.md:

_# How to install

Install by running `setup.py

* Open a Terminal (Linux/macOS) or Command Prompt (Windows), navigate into the top-level railFE directory and activate your environment of choice. Run the following command:
```
(ODYM)$ python setup.py install
```

# Examples / How to run

An example of the application of ODYM for DSM can be obtained by running the following file [DSM_test_known_results](odym/modules/test/DSM_test_known_results.py)_


Best regards,
Cyprien
